### PR TITLE
Fix connection error handling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db-cli (1.4.6) stable; urgency=medium
+
+  * Fix connection error handling
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 15 Jul 2024 16:27:00 +0400
+
 wb-mqtt-db-cli (1.4.5) stable; urgency=medium
 
   * Fix error that caused to print only one result row

--- a/wb-mqtt-db-cli.py
+++ b/wb-mqtt-db-cli.py
@@ -152,7 +152,11 @@ def main():
     client = MQTTClient("wb-mqtt-db-cli", args.broker_url)
     rpc_client = TMQTTRPCClient(client)
     client.on_message = rpc_client.on_mqtt_message
-    client.start()
+    try:
+        client.start()
+    except (ConnectionError, ConnectionRefusedError):
+        print(f"Cannot connect to broker {args.broker_url}")
+        sys.exit(1)
 
     channels = [channel.split("/", 2) for channel in args.channels]
 
@@ -229,4 +233,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)


### PR DESCRIPTION
Before:
```sh
# wb-mqtt-db-cli -b tcp://127.0.0.1:1883 metrics/ram_used
Traceback (most recent call last):
  File "/usr/bin/wb-mqtt-db-cli", line 232, in <module>
    main()
  File "/usr/bin/wb-mqtt-db-cli", line 155, in main
    client.start()
  File "/usr/lib/python3/dist-packages/wb_common/mqtt_client.py", line 42, in start
    self.connect(self._broker_url.hostname, self._broker_url.port)
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 941, in connect
    return self.reconnect()
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1075, in reconnect
    sock = self._create_socket_connection()
  File "/usr/lib/python3/dist-packages/paho_socket/client.py", line 95, in _create_socket_connection
    return super()._create_socket_connection()
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 3546, in _create_socket_connection
    return socket.create_connection(addr, source_address=source, timeout=self._keepalive)
  File "/usr/lib/python3.9/socket.py", line 843, in create_connection
    raise err
  File "/usr/lib/python3.9/socket.py", line 831, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused
# wb-mqtt-db-cli metrics/ram_used
<...>
metrics/ram_used	2024-07-15 12:21:12.160000	175	174	177
^CTraceback (most recent call last):
  File "/usr/bin/wb-mqtt-db-cli", line 232, in <module>
    main()
  File "/usr/bin/wb-mqtt-db-cli", line 227, in main
    client.stop()
  File "/usr/lib/python3/dist-packages/wb_common/mqtt_client.py", line 51, in stop
    self.loop_stop()
  File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 1836, in loop_stop
    self._thread.join()
  File "/usr/lib/python3.9/threading.py", line 1033, in join
    self._wait_for_tstate_lock()
  File "/usr/lib/python3.9/threading.py", line 1049, in _wait_for_tstate_lock
    elif lock.acquire(block, timeout):
KeyboardInterrupt
```

After:
```sh
# wb-mqtt-db-cli -b tcp://127.0.0.1:1883 metrics/ram_used
Cannot connect to broker tcp://127.0.0.1:1883
# wb-mqtt-db-cli metrics/ram_used
<...>
metrics/ram_used	2024-07-15 07:59:12.082000	168	166	169
^C
```